### PR TITLE
Compatibility fix for VirtualBox

### DIFF
--- a/main.c
+++ b/main.c
@@ -221,9 +221,9 @@ int main (int argc, char *argv[])
   if (sz & (LOG_PAGE_SIZE -1))
     die ("file size not multiple of page size");
 
-  flash = mmap (0, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  flash = malloc(sz);
   if (!flash)
-    die ("mmap");
+    die ("malloc");
 
   if (create)
     memset (flash, 0xff, sz);
@@ -324,7 +324,9 @@ int main (int argc, char *argv[])
   }
 
   SPIFFS_unmount (&fs);
-  munmap (flash, sz);
+  lseek(fd, 0, SEEK_SET);
+  write(fd, flash, sz);
   close (fd);
+  free(flash);
   return retcode;
 }

--- a/main.c
+++ b/main.c
@@ -221,7 +221,7 @@ int main (int argc, char *argv[])
   if (sz & (LOG_PAGE_SIZE -1))
     die ("file size not multiple of page size");
 
-  flash = malloc(sz);
+  flash = (uint8_t *)malloc(sz);
   if (!flash)
     die ("malloc");
 


### PR DESCRIPTION
mmap with option MAP_SHARED will cause (void *)-1 with errno = invalid argument error returned and furthermore cause a segmentation fault.

Refer https://www.virtualbox.org/ticket/819

This can be reproduced using the espressif VM image under VirtualBox.

I replaced the mmap with a malloc and a later write back + free.
